### PR TITLE
Dr/product link cards

### DIFF
--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -2,13 +2,13 @@
 .zoomywishid .zoomywishidheart {
   width: fit-content !important;
   float: none !important;
-  cursor: pointer;
-  z-index: 10;
+  z-index: 2;
 }
 
 .fa.fa-heart-o,
 .fa.fa-heart {
   padding: 0 !important;
+  cursor: pointer;
 }
 
 .card-wrapper {

--- a/assets/global-tailwind.css
+++ b/assets/global-tailwind.css
@@ -678,6 +678,10 @@ video {
   z-index: 3;
 }
 
+.z-\[2\]{
+  z-index: 2;
+}
+
 .m-0{
   margin: 0px;
 }
@@ -778,16 +782,16 @@ video {
   margin-top: 0.5rem;
 }
 
+.mt-24{
+  margin-top: 6rem;
+}
+
 .mt-6{
   margin-top: 1.5rem;
 }
 
 .mt-8{
   margin-top: 2rem;
-}
-
-.mt-24{
-  margin-top: 6rem;
 }
 
 .block{

--- a/assets/global-tailwind.css
+++ b/assets/global-tailwind.css
@@ -654,6 +654,30 @@ video {
   top: 100%;
 }
 
+.bottom-\[1px\]{
+  bottom: 1px;
+}
+
+.right-\[1px\]{
+  right: 1px;
+}
+
+.-bottom-\[1px\]{
+  bottom: -1px;
+}
+
+.-right-\[1px\]{
+  right: -1px;
+}
+
+.-bottom-\[2px\]{
+  bottom: -2px;
+}
+
+.-right-\[2px\]{
+  right: -2px;
+}
+
 .isolate{
   isolation: isolate;
 }
@@ -794,6 +818,14 @@ video {
   margin-top: 2rem;
 }
 
+.mt-4{
+  margin-top: 1rem;
+}
+
+.mt-3{
+  margin-top: 0.75rem;
+}
+
 .block{
   display: block;
 }
@@ -816,6 +848,10 @@ video {
 
 .hidden{
   display: none;
+}
+
+.aspect-square{
+  aspect-ratio: 1 / 1;
 }
 
 .h-14{
@@ -844,6 +880,10 @@ video {
 
 .h-full{
   height: 100%;
+}
+
+.h-auto{
+  height: auto;
 }
 
 .max-h-\[10rem\]{
@@ -2180,6 +2220,10 @@ input{
 
   .lg\:h-auto{
     height: auto;
+  }
+
+  .lg\:h-full{
+    height: 100%;
   }
 
   .lg\:min-h-0{

--- a/sections/link-blocks.liquid
+++ b/sections/link-blocks.liquid
@@ -24,7 +24,7 @@
 			{% for block in section.blocks %}
 				<div class="min-w-[256px] lg:min-w-0 flex-shrink-0">
 					<a class="full-unstyled-link group relative" href="{{ block.settings.link }}">
-						<div class="border border-solid border-[#EEEEEE] h-[256px]">
+						<div class="border border-solid border-[#EEEEEE] h-auto relative">
 							<div class="overflow-hidden">
 								<img
 								src="{{ block.settings.link_image | image_url: height: 256 }}"
@@ -32,10 +32,10 @@
 								width="256"
 								height="256"
 								loading="lazy"
-								class="object-cover w-full h-full group-hover:scale-105 transition-all duration-500"
+								class="object-cover w-full h-full group-hover:scale-105 transition-all duration-500 aspect-square"
 								>
 							</div>
-							<div class="absolute top-[calc(256px-63px)] right-0">
+							<div class="absolute -bottom-[1px] -right-[1px]">
 								<svg width="63" height="63" viewBox="0 0 63 63" fill="none" xmlns="http://www.w3.org/2000/svg">
 									<path d="M62.9998 62.6667V0.637695L0.970703 62.6667H62.9998Z" class="transition-all fill-brand-orange group-hover:fill-brand-blue" />
 								</svg>
@@ -44,7 +44,7 @@
 								</svg>
 							</div>
 						</div>
-						<p class="text-1.4">{{ block.settings.link_title }}</p>
+						<p class="text-1.4 mt-3">{{ block.settings.link_title }}</p>
 					</a>
 				</div>
 			{% endfor %}

--- a/snippets/card-product.liquid
+++ b/snippets/card-product.liquid
@@ -138,7 +138,7 @@
             <div class="flex w-full items-start justify-between">
               {% render 'price', product: card_product, price_class: '', show_compare_at_price: true %}
               {% if quick_add == 'standard' %}
-                <div class="quick-add no-js-hidden z-10">
+                <div class="quick-add no-js-hidden z-[2]">
                   {%- liquid
                     assign product_form_id = 'quick-add-' | append: section_id | append: card_product.id
                     assign qty_rules = false


### PR DESCRIPTION
Z-index allows users to cursor over the ATC/wishlist buttons instead of the entire product hyperlink but accidentally used Tailwind's default to 10 - adjusted to 2 to avoid clipping into sticky header/other elements